### PR TITLE
Stop debugpy session from hanging with env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The module is helping you with:
 This will create needed structure for your plugin
 
 1. Create new plugin using [cookiecutter-qgis-plugin](https://github.com/GispoCoding/cookiecutter-qgis-plugin).
-   This will automatically initialize git add qgis_plugin_tools as a submodule to the plugin.
+   This will automatically initialize git and add qgis_plugin_tools as a submodule for the plugin.
 1. Next set up the [development environment](infrastructure/template/root/docs/development.md#Setting-up-development-environment),
    edit metadata.txt with description etc. and commit changes.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -119,10 +119,10 @@ Plugin can connect to already running debug server with following code in the pl
 Check out comments in [debugging.py](../infrastructure/debugging.py).
 
 ```python
-from .qgis_plugin_tools.infrastructure.debugging import setup_pydevd
+from .qgis_plugin_tools.infrastructure.debugging import setup_pydevd, setup_debugpy
 
 # It is a good idea to set up an environment variable to control this. Like:
-# if os.environ.get('QGIS_PLUGIN_DEBUGGER') == 'pydevd':
+# if os.environ.get('QGIS_PLUGIN_USE_DEBUGGER') == 'pydevd':
 setup_pydevd()
 ```
 

--- a/infrastructure/debugging.py
+++ b/infrastructure/debugging.py
@@ -130,9 +130,6 @@ def setup_debugpy(host: str = "localhost", port: int = 5678) -> bool:
     succeeded = False
     if _check_if_should_setup() and not os.environ.get("QGIS_DEBUGPY_HAS_LOADED"):
         try:
-            # extra guard for debugpy not to setup it twice
-            # (causes debugging session to hang)
-            os.environ["QGIS_DEBUGPY_HAS_LOADED"] = "1"
             import debugpy
 
             debugpy.configure(python=shutil.which("python"))
@@ -140,4 +137,9 @@ def setup_debugpy(host: str = "localhost", port: int = 5678) -> bool:
             succeeded = True
         except Exception as e:
             print("Unable to create debugpy debugger: {}".format(e))
+        else:
+            # extra guard for debugpy not to setup it twice
+            # (causes debugging session to hang)
+            os.environ["QGIS_DEBUGPY_HAS_LOADED"] = "1"
+
     return succeeded

--- a/infrastructure/debugging.py
+++ b/infrastructure/debugging.py
@@ -5,6 +5,7 @@ __email__ = "info@gispo.fi"
 __revision__ = "$Format:%H$"
 
 import os
+import shutil
 import sys
 
 
@@ -134,7 +135,7 @@ def setup_debugpy(host: str = "localhost", port: int = 5678) -> bool:
             os.environ["QGIS_DEBUGPY_HAS_LOADED"] = "1"
             import debugpy
 
-            debugpy.configure(python=sys.executable)
+            debugpy.configure(python=shutil.which("python"))
             debugpy.listen((host, port))
             succeeded = True
         except Exception as e:

--- a/infrastructure/debugging.py
+++ b/infrastructure/debugging.py
@@ -4,6 +4,14 @@ __license__ = "GPL version 3"
 __email__ = "info@gispo.fi"
 __revision__ = "$Format:%H$"
 
+import os
+import sys
+
+
+def _check_if_should_setup() -> bool:
+    """ Check whether to connect to debug server or not """
+    return "pytest" not in sys.modules and not os.environ.get("QGIS_PLUGIN_IN_CI")
+
 
 def setup_pydevd(host: str = "localhost", port: int = 5678) -> bool:
     """
@@ -32,13 +40,14 @@ def setup_pydevd(host: str = "localhost", port: int = 5678) -> bool:
     :return: Whether debugger was initialized properly or not
     """
     succeeded = False
-    try:
-        import pydevd
+    if _check_if_should_setup():
+        try:
+            import pydevd
 
-        pydevd.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
-        succeeded = True
-    except Exception as e:
-        print("Unable to create pydevd debugger: {}".format(e))
+            pydevd.settrace(host, port=port, stdoutToServer=True, stderrToServer=True)
+            succeeded = True
+        except Exception as e:
+            print("Unable to create pydevd debugger: {}".format(e))
 
     return succeeded
 
@@ -46,9 +55,6 @@ def setup_pydevd(host: str = "localhost", port: int = 5678) -> bool:
 def setup_ptvsd(host: str = "localhost", port: int = 5678) -> bool:
     """
     Setup ptvsd degugging service
-
-    Currently, debugging with VSCode requires the deprecated ptvsd library, due to a bug in debugpy:
-    https://github.com/microsoft/debugpy/issues/586
 
     Here is a sample VSCode configuration for connecting to the debug server in launch.json:
 
@@ -70,37 +76,67 @@ def setup_ptvsd(host: str = "localhost", port: int = 5678) -> bool:
                 }
             ]
         }
-    ]
+      ]
+    }
 
     :param host: host of the debug server
     :param port: port of the debug server
     :return: Whether debugger was initialized properly or not
     """
     succeeded = False
-    try:
-        import ptvsd
+    if _check_if_should_setup():
+        try:
+            import ptvsd
 
-        ptvsd.enable_attach((host, port))
-        succeeded = True
-    except Exception as e:
-        print("Unable to create ptvsd debugger: {}".format(e))
+            ptvsd.enable_attach((host, port))
+            succeeded = True
+        except Exception as e:
+            print("Unable to create ptvsd debugger: {}".format(e))
     return succeeded
 
 
 def setup_debugpy(host: str = "localhost", port: int = 5678) -> bool:
     """
-    Setup debugpy degugging service
+    Setup debugpy debugging service
+
+    Here is a sample VSCode configuration for connecting to the debug server in launch.json:
+
+    {
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Remote Attach",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}/<plugin_name>",
+                    "remoteRoot": "/Users/<user_name>/Library/Application Support/QGIS/QGIS3/profiles/edplanning/python/plugins/<plugin_name>"
+                }
+            ]
+        }
+      ]
+    }
 
     :param host: host of the debug server
     :param port: port of the debug server
     :return: Whether debugger was initialized properly or not
     """
     succeeded = False
-    try:
-        import debugpy
+    if _check_if_should_setup() and not os.environ.get("QGIS_DEBUGPY_HAS_LOADED"):
+        try:
+            # extra guard for debugpy not to setup it twice
+            # (causes debugging session to hang)
+            os.environ["QGIS_DEBUGPY_HAS_LOADED"] = "1"
+            import debugpy
 
-        debugpy.listen((host, port))
-        succeeded = True
-    except Exception as e:
-        print("Unable to create debugpy debugger: {}".format(e))
+            debugpy.configure(python=sys.executable)
+            debugpy.listen((host, port))
+            succeeded = True
+        except Exception as e:
+            print("Unable to create debugpy debugger: {}".format(e))
     return succeeded


### PR DESCRIPTION
Debugpy might hang if using Plugin Reloader inside debug session. This PR prevents this by setting env variable to check whether the session has been started or not.