### PR TITLE
Fix test runner with latest QGIS version and recommend pytest-qgis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
   test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker_tags: [ release-3_16 ]
+      fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -26,9 +30,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Pull qgis 3.14 image
-        run: docker pull qgis/qgis:release-3_14
+      - name: Pull qgis LTR image
+        run: docker pull qgis/qgis:${{ matrix.docker_tags }}
 
       # Runs all tests
-      - name: Run tests (3.14)
-        run: docker run --rm --net=host --volume `pwd`:/app -w=/app -e QGIS_PLUGIN_IN_CI=1 -e QGIS_PLUGIN_TOOLS_IN_CI=1 qgis/qgis:release-3_14 sh -c "pip3 install -q pytest && xvfb-run -s '+extension GLX -screen 0 1024x768x24' pytest -v"
+      - name: Run tests
+        run: >
+          docker run --rm --net=host --volume `pwd`:/app -w=/app -e QGIS_PLUGIN_IN_CI=1 qgis/qgis:${{ matrix.docker_tags }} sh -c
+          "pip3 install -qr requirements-dev.txt && xvfb-run -s '+extension GLX -screen 0 1024x768x24'
+          pytest -v"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+pytest-qgis~=0.1.0

--- a/testing/utilities.py
+++ b/testing/utilities.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import sys
+import warnings
 
 from osgeo import gdal
 from qgis.core import Qgis
@@ -39,7 +40,10 @@ def get_qgis_app():  # noqa
 
     If QGIS is already running the handle to that app will be returned.
     """
-
+    warnings.warn(
+        "get_qgis_app() will be deprecated. Use library pytest-qgis instead.",
+        PendingDeprecationWarning,
+    )
     try:
         from qgis.core import QgsApplication
         from qgis.gui import QgsMapCanvas
@@ -54,7 +58,7 @@ def get_qgis_app():  # noqa
     if QGIS_APP is None:
         gui_flag = True  # All test will run qgis in gui mode
         # noinspection PyPep8Naming
-        QGIS_APP = QgsApplication([bytes(arg, "utf-8") for arg in sys.argv], gui_flag)
+        QGIS_APP = QgsApplication([], gui_flag)
         # Make sure QGIS_PREFIX_PATH is set in your env if needed!
         QGIS_APP.initQgis()
         s = QGIS_APP.showSettings()


### PR DESCRIPTION
There was a problems when running tests in newest version of QGIS in Intellij IDEA. Removing run args from `QgsApplication` fixed it. Also the whole `testing.utilities.get_qgis_app` was marked deprecated in favor of [pytest-qgis](https://github.com/GispoCoding/pytest-qgis).