### PR TITLE
Add packaging config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,57 @@ extend-ignore =
 # Black compatible values for isort https://black.readthedocs.io/en/stable/compatible_configs.html#isort
 profile = black
 multi_line_output = 3
+
+[metadata]
+# ?
+name = qgis_plugin_tools
+# ?
+version = 0.0.1
+# author = ?
+# author_email = ?
+# maintainer = ?
+# maintainer_email = ?
+# description = ?
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords = qgis,QGIS,PyQGIS
+url = https://github.com/GispoCoding/qgis_plugin_tools
+license = GNU GPL v2.0
+
+# https://pypi.org/pypi?%3Aaction=list_classifiers
+classifiers =
+     Development Status :: 4 - Beta
+     Intended Audience :: Developers
+     Topic :: Software Development :: Libraries :: Python Modules
+     Programming Language :: Python
+     Programming Language :: Python :: 3
+     Programming Language :: Python :: 3.5
+     Programming Language :: Python :: 3.6
+     Programming Language :: Python :: 3.7
+     Programming Language :: Python :: 3.8
+     Programming Language :: Python :: 3 :: Only
+     Programming Language :: Python :: Implementation :: CPython
+     Programming Language :: Python :: Implementation :: PyPy
+     Operating System :: OS Independent
+     License :: OSI Approved :: GNU General Public License v2 (GPLv2)
+
+[options]
+python_requires = >=3.5
+packages =
+    qgis_plugin_tools
+    qgis_plugin_tools.infrastructure
+    qgis_plugin_tools.resources
+    qgis_plugin_tools.resources.ui
+    qgis_plugin_tools.testing
+    qgis_plugin_tools.tools
+    qgis_plugin_tools.widgets
+package_dir =
+    qgis_plugin_tools = .
+
+# due to .ui files actually needed on disk when using __file__ relative paths?
+zip_safe = False
+
+[options.package_data]
+* =
+    py.typed
+    *.ui

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+#  Copyright (C) 2022 qgis_plugin_tools Contributors.
+#
+#
+#  This file is part of qgis_plugin_tools.
+#
+#  qgis_plugin_tools is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  qgis_plugin_tools is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with qgis_plugin_tools.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Add setup.py and relevant metadata to setup.cfg.

Allows installing this project from the git repo also as a standalone package instead of being submodule-use only.

Maybe could publish to PyPI also?