### PR TITLE
Change logging and resources to work better with module namespaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
     rev: 21.12b0
     hooks:
       - id: black
+        additional_dependencies:
+          - click==8.0.4
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,31 +3,38 @@
 ## Logging
 
 For setting up the logging (usually in main plugin file):
+
 ```python
-from .qgis_plugin_tools.tools.resources import plugin_name
-from .qgis_plugin_tools.tools.custom_logging import setup_logger, add_logger_msg_bar_to_widget
+# Setup loggers usually in initGui, with the plugin package name passed as the root
+# logger namespace
 
-# Setup without message bar support
-# setup_logger(plugin_name())
+from qgis_plugin_tools.tools.custom_logging import setup_logger
 
-# Setup with QGIS interface to add message bar support
-setup_logger(plugin_name(), iface)
+setup_logger(__name__.split('.')[0]) # use the top level name
+setup_logger("your_plugin_package_name") # pass manually as string
 
-# If you want to add a message bar widget to a dialog, you can setup that like this:
+# In some cases you might want to add a message bar to a dialog and use logging
+# from there, this adds message_bar to dialog and uses it with message bar
+# logging handler
+
+from qgis_plugin_tools.tools.custom_logging import add_logger_msg_bar_to_widget
+
 dialog = Dialog()
-# adds message_bar to dialog and uses it with message bar logging handler
-add_logger_msg_bar_to_widget(plugin_name(), dialog)
+add_logger_msg_bar_to_widget(dialog)
+
+# teardown the handlers in plugin unload
+
+from qgis_plugin_tools.tools.custom_logging import teardown_logger
+
+teardown_logger("your_plugin_package_name")
 ```
 
-To use the logging system:
+To use the logging system in plugin files:
+
 ```python
 import logging
-from .qgis_plugin_tools.tools.resources import plugin_name
-from .qgis_plugin_tools.tools.custom_logging import bar_msg
-from .qgis_plugin_tools.tools.messages import MsgBar
 
-# Top of the file
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 
 # Later in the code
 LOGGER.debug('Log some debug messages')
@@ -36,14 +43,24 @@ LOGGER.warning('Log a warning here')
 LOGGER.error('Log an error here')
 LOGGER.critical('Log a critical error here')
 
-# These are logged to the message bar (main window's or dialog's) in addition to normal logging
+# To show a message bar in addition to logging a message use
+# either MsgBar helpers
+
+from qgis_plugin_tools.tools.messages import MsgBar
+
 MsgBar.info("Msg bar message", "some details here")
 MsgBar.warning('Msg bar message', "some details here", success=True)
+
+# or "extra" kwarg dict with data, creatable also with bar_msg helper
+
+from qgis_plugin_tools.tools.custom_logging import bar_msg
+
 LOGGER.warning('Msg bar message', extra={'details:': "some details here"})
 LOGGER.error('Msg bar message', extra=bar_msg("some details here", duration=10))
 ```
 
 ## Exceptions
+
 Use [`QgsPluginException`](../tools/exceptions.py) as a base class for every exception. This makes it easy to catch
 all user thrown exceptions at the same time, and you can even use the bar messages in exceptions.
 
@@ -64,12 +81,11 @@ except Exception as e:
 
 Check [tests](../testing/test_decorations.py) for more examples.
 
-
 ## Network tools
+
 Network tools include blocking network utils using QGIS best practices.
 Use this instead of `requests` or `urllib` modules.
 Check [tests](../testing/test_network.py) for more examples.
-
 
 ```python
 from .qgis_plugin_tools.tools.network import fetch
@@ -78,10 +94,12 @@ contents = fetch('www.examapleurl.com')
 ```
 
 ## Settings tools
+
 [This module](../tools/settings.py) includes tool to save and load QGIS profile settings easily.
 Check [tests](../testing/test_settings.py) for examples.
 
 ## Resource tools
+
 [This module](../tools/resources.py) provides easy way to get paths to various files in
 plugin directories. For example to fetch ui file from resources/ui folder use
 `load_ui('resource-file.ui)`.
@@ -89,9 +107,9 @@ plugin directories. For example to fetch ui file from resources/ui folder use
 ## Translating
 
 ### Using translations in code
+
 It is a good practice to use wrap every meaningful log or message string inside `tr`
 to make it possibly translatable.
-
 
 ```python
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
@@ -112,9 +130,11 @@ tr('{} + {} is definitely {}', 1,1,3)
 ```
 
 ### Setting up translations
+
 Check out [translation guide](../infrastructure/template/root/docs/development.md#Translating).
 
 ## Debug server
+
 Plugin can connect to already running debug server with following code in the plugin's `__init__.py` file.
 Check out comments in [debugging.py](../infrastructure/debugging.py).
 
@@ -126,8 +146,8 @@ from .qgis_plugin_tools.infrastructure.debugging import setup_pydevd, setup_debu
 setup_pydevd()
 ```
 
-
 ## Using PluginMaker
+
 There is a script [plugin_maker.py](infrastructure/plugin_maker.py), which can
 be used to replace Makefile and pb_tool in plugin build, deployment, translation and packaging processes.
 To use it, create a python script (eg. build.py) in the root of the plugin and
@@ -158,7 +178,9 @@ compiled_resources = ["resources.py"]
 PluginMaker(py_files=py_files, ui_files=ui_files, resources=resources, extra_dirs=extra_dirs,
             compiled_resources=compiled_resources, locales=locales, profile=profile)
 ```
+
 And use it like:
+
 ```shell script
 python build.py -h # Show available commands
 python build.py deploy

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,13 +9,22 @@ __revision__ = "$Format:%H$"
 import pytest
 
 from ..testing.utilities import TestTaskRunner
-from ..tools.custom_logging import setup_logger, teardown_logger
+from ..tools.custom_logging import (
+    LogTarget,
+    get_log_level_key,
+    setup_logger,
+    teardown_logger,
+)
 from ..tools.resources import plugin_name
+from ..tools.settings import set_setting
 
 
 @pytest.fixture(scope="session")
 def initialize_logger(qgis_iface):
+    set_setting(get_log_level_key(LogTarget.FILE), "NOTSET")
     setup_logger(plugin_name(), qgis_iface)
+    yield
+    teardown_logger(plugin_name())
 
 
 @pytest.fixture()

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,26 @@
+from threading import Thread
+from unittest.mock import MagicMock
+
+from qgis.PyQt.QtCore import QCoreApplication
+
+from ..tools.custom_logging import SimpleMessageBarProxy
+
+
+def test_message_log_proxies_between_threads():
+    mock_msg_bar = MagicMock()
+    proxy = SimpleMessageBarProxy(mock_msg_bar)
+
+    def mock_thread():
+        proxy.emit_message("title", "text", 1, 2)
+
+    thread = Thread(target=mock_thread)
+    thread.start()
+
+    mock_msg_bar.pushMessage.assert_not_called()
+    thread.join(5)
+    assert not thread.is_alive()
+
+    QCoreApplication.processEvents()
+    mock_msg_bar.pushMessage.assert_called_once_with(
+        title="title", text="text", level=1, duration=2
+    )

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -1,6 +1,7 @@
 import time
 
 from qgis.core import Qgis
+from qgis.PyQt.QtCore import QCoreApplication, QEventLoop
 
 from ..testing.utilities import SimpleTask, TestTaskRunner
 from ..tools.exceptions import QgsPluginException, TaskInterruptedException
@@ -28,6 +29,10 @@ def test_run_simple_task(task_runner: TestTaskRunner):
 def test_run_simple_task_canceled(task_runner: TestTaskRunner, qgis_iface):
     task = SimpleTask()
     success = task_runner.run_task(task, cancel=True)
+
+    # for some reason this randomly fails if the signal is not waited for
+    QCoreApplication.processEvents(QEventLoop.AllEvents, 100)  # 100 ms wait
+
     messages = qgis_iface.messageBar().get_messages(Qgis.Warning)
 
     assert not success

--- a/tools/custom_logging.py
+++ b/tools/custom_logging.py
@@ -362,7 +362,7 @@ def setup_logger(  # noqa QGS105
     # qgis_plugin_tools namespace for MsgBar and others to work properly using __name__
     logger_names = [logger_name]
     if logger_name == plugin_name():
-        logger_names.append(__name__.removesuffix(".tools.custom_logging"))
+        logger_names.append(__name__.replace(".tools.custom_logging", "", 1))
 
     for logger_name in logger_names:
         logger = logging.getLogger(logger_name)
@@ -425,7 +425,7 @@ def teardown_logger(logger_name: str) -> None:
 
     # if the logger name was plugin_name(), also clean up the special case logger
     if logger_name == plugin_name():
-        teardown_logger(__name__.removesuffix(".tools.custom_logging"))
+        teardown_logger(__name__.replace(".tools.custom_logging", "", 1))
 
 
 def teardown_loggers(logger_names: List[str]) -> None:

--- a/tools/custom_logging.py
+++ b/tools/custom_logging.py
@@ -2,7 +2,6 @@
 
 import functools
 import logging
-import warnings
 from enum import Enum, unique
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -413,29 +412,6 @@ def use_custom_msg_bar_in_logger(logger_name: str, msg_bar: QgsMessageBar) -> No
     qgis_msg_bar_handler.addFilter(QgsMessageBarFilter())
     qgis_msg_bar_handler.setLevel(bar_level)
     add_logging_handler_once(logger, qgis_msg_bar_handler)
-
-
-def setup_task_logger(logger_name: str) -> logging.Logger:
-    """Run once when the module is loaded and enable logging during tasks.
-
-    :param logger_name: The logger name that we want to set up.
-    """
-
-    warnings.warn(
-        "setup_task_logger() will be deprecated. Use setup_logger() instead.",
-        PendingDeprecationWarning,
-    )
-    stream_level = get_log_level(LogTarget.STREAM)
-    logger = logging.getLogger(f"{logger_name}_task")
-    logger.setLevel(stream_level)
-    logger.handlers = []
-
-    qgis_handler = QgsLogHandler()
-    qgis_formatter = logging.Formatter("[%(levelname)-7s]- %(message)s")
-    qgis_handler.setFormatter(qgis_formatter)
-    add_logging_handler_once(logger, qgis_handler)
-
-    return logger
 
 
 def teardown_logger(logger_name: str) -> None:

--- a/tools/layers.py
+++ b/tools/layers.py
@@ -23,14 +23,13 @@ from qgis.core import (
 from .custom_logging import bar_msg
 from .exceptions import QgsPluginExpressionException
 from .i18n import tr
-from .resources import plugin_name
 
 try:
     from qgis.core import QgsUnitTypes, QgsVectorLayerTemporalProperties
 except ImportError:
     QgsVectorLayerTemporalProperties = QgsUnitTypes = None
 
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 
 POINT_TYPES = {
     QgsWkbTypes.Point,

--- a/tools/logger_processing.py
+++ b/tools/logger_processing.py
@@ -3,14 +3,12 @@ import logging
 
 from qgis.core import QgsProcessingFeedback
 
-from .custom_logging import plugin_name
-
 __copyright__ = "Copyright 2020-2021, Gispo Ltd"
 __license__ = "GPL version 3"
 __email__ = "info@gispo.fi"
 __revision__ = "$Format:%H$"
 
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 
 
 class LoggerProcessingFeedBack(QgsProcessingFeedback):

--- a/tools/messages.py
+++ b/tools/messages.py
@@ -3,28 +3,26 @@ import sys
 from typing import Any, Dict, Optional
 
 from .custom_logging import bar_msg
-from .resources import plugin_name
-
-LOGGER = logging.getLogger(plugin_name())
 
 
-class MsgBar:
+class MessageBarLogger:
     """
-    This static class is used to log messages to the Qgis message bar.
-    Uses custom_logging.py's QgsMessageBarHandler under the hood.
+    logging.Logger like interface to push messages to the
+    message bar where necessary with info/warning/etc methods.
 
-    bar_msg could be used like this:
-    MsgBar.exception("main message", **bar_msg)
+    Setup with a logger name that has a message bar set.
     """
 
-    KWARGS: Dict[str, Any] = (
-        {}
-        if sys.version_info.major == 3 and sys.version_info.minor < 8
-        else {"stacklevel": 2}
-    )
+    def __init__(self, logger_name: str) -> None:
+        self._logger = logging.getLogger(logger_name)
+        self._logger_kwargs: Dict[str, Any] = (
+            {}
+            if sys.version_info.major == 3 and sys.version_info.minor < 8
+            else {"stacklevel": 2}
+        )
 
-    @staticmethod
     def info(
+        self,
         message: Any,
         details: Any = "",
         duration: Optional[int] = None,
@@ -40,14 +38,16 @@ class MsgBar:
         :param success: Whether the message is success message or not
         """
 
-        LOGGER.info(
-            str(message), extra=bar_msg(details, duration, success), **MsgBar.KWARGS
+        self._logger.info(
+            str(message),
+            extra=bar_msg(details, duration, success),
+            **self._logger_kwargs
         )
         if details != "":
-            LOGGER.info(str(details), **MsgBar.KWARGS)
+            self._logger.info(str(details), **self._logger_kwargs)
 
-    @staticmethod
     def warning(
+        self,
         message: Any,
         details: Any = "",
         duration: Optional[int] = None,
@@ -62,14 +62,16 @@ class MsgBar:
             by the user.
         :param success: Whether the message is success message or not
         """
-        LOGGER.warning(
-            str(message), extra=bar_msg(details, duration, success), **MsgBar.KWARGS
+        self._logger.warning(
+            str(message),
+            extra=bar_msg(details, duration, success),
+            **self._logger_kwargs
         )
         if details != "":
-            LOGGER.warning(str(details), **MsgBar.KWARGS)
+            self._logger.warning(str(details), **self._logger_kwargs)
 
-    @staticmethod
     def error(
+        self,
         message: Any,
         details: Any = "",
         duration: Optional[int] = None,
@@ -85,14 +87,16 @@ class MsgBar:
             by the user.
         :param success: Whether the message is success message or not
         """
-        LOGGER.error(
-            str(message), extra=bar_msg(details, duration, success), **MsgBar.KWARGS
+        self._logger.error(
+            str(message),
+            extra=bar_msg(details, duration, success),
+            **self._logger_kwargs
         )
         if details != "":
-            LOGGER.error(str(details), **MsgBar.KWARGS)
+            self._logger.error(str(details), **self._logger_kwargs)
 
-    @staticmethod
     def exception(
+        self,
         message: Any,
         details: Any = "",
         duration: Optional[int] = None,
@@ -108,8 +112,14 @@ class MsgBar:
             by the user.
         :param success: Whether the message is success message or not
         """
-        LOGGER.exception(
-            str(message), extra=bar_msg(details, duration, success), **MsgBar.KWARGS
+        self._logger.exception(
+            str(message),
+            extra=bar_msg(details, duration, success),
+            **self._logger_kwargs
         )
         if details != "":
-            LOGGER.error(str(details), **MsgBar.KWARGS)
+            self._logger.error(str(details), **self._logger_kwargs)
+
+
+# publish the old MsgBar with the default logger name
+MsgBar = MessageBarLogger(__name__)

--- a/tools/network.py
+++ b/tools/network.py
@@ -26,7 +26,7 @@ __license__ = "GPL version 3"
 __email__ = "info@gispo.fi"
 __revision__ = "$Format:%H$"
 
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 ENCODING = "utf-8"
 CONTENT_DISPOSITION_HEADER = "Content-Disposition"
 CONTENT_DISPOSITION_BYTE_HEADER = QByteArray(

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -6,9 +6,8 @@ from qgis.core import QgsTask
 from .exceptions import QgsPluginException, TaskInterruptedException
 from .i18n import tr
 from .messages import MsgBar
-from .resources import plugin_name
 
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 
 __copyright__ = "Copyright 2021, qgis_plugin_tools contributors"
 __license__ = "GPL version 3"

--- a/widgets/progress_dialog.py
+++ b/widgets/progress_dialog.py
@@ -23,11 +23,11 @@ from qgis.PyQt.QtWidgets import (
 
 from ..tools.decorations import log_if_fails
 from ..tools.i18n import tr
-from ..tools.resources import plugin_name, qgis_plugin_tools_resources
+from ..tools.resources import qgis_plugin_tools_resources
 
 FORM_CLASS: QWidget
 FORM_CLASS, _ = uic.loadUiType(qgis_plugin_tools_resources("ui", "progress_dialog.ui"))
-LOGGER = logging.getLogger(plugin_name())
+LOGGER = logging.getLogger(__name__)
 
 
 class ProgressDialog(QDialog, FORM_CLASS):


### PR DESCRIPTION
* Use module namespace logging and change the APIs to allow using `__name__` also in plugins that use this module. Try to preserve current usage with `plugin_name()` by making a special case for namespace logger.
* Fix multithreading issues with message bars by implementing a simple QObject proxy signal-slot pair, since pushMessage must be called in the GUI thread.
* Change resource path code to find the root as relative to top level module instead, and allow using as a dependency by using inspect to find the caller plugin top level module.
* Deprecate task logger.

Needs a version bump to 0.2.0?