### PR TITLE
Add api for safer file access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,24 +18,25 @@ jobs:
   test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    container:
+      image: qgis/qgis:${{ matrix.qgis-image-tag }}
     strategy:
       matrix:
-        docker_tags: [ release-3_16, release-3_22, release-3_28 ]
+        qgis-image-tag:
+          - release-3_16
+          - release-3_22
+          - release-3_28
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Pull qgis LTR image
-        run: docker pull qgis/qgis:${{ matrix.docker_tags }}
-
-      # Runs all tests
-      - name: Run tests
-        run: >
-          docker run --rm --net=host --volume `pwd`:/app -w=/app -e QGIS_PLUGIN_IN_CI=1 -e QGIS_PLUGIN_TOOLS_IN_CI=1
-          qgis/qgis:${{ matrix.docker_tags }} sh -c
-          "pip3 install -qr requirements-dev.txt && xvfb-run -s '+extension GLX -screen 0 1024x768x24' pytest -v"
+      - uses: actions/checkout@v3
+      - run: |
+          pip3 install -qr requirements-dev.txt
+      - run: |
+          pytest -v
+        env:
+          QT_QPA_PLATFORM: offscreen
+          QGIS_PLUGIN_IN_CI: 1
+          QGIS_PLUGIN_TOOLS_IN_CI: 1

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -131,7 +131,7 @@ def plugin_name() -> str:
 
     # if qgis plugin tools is run as a dependency, global var cannot be set
     # since it might confuse multiple plugins in the same env using this fn
-    if not _IS_SUBMODULE_USAGE:
+    if _IS_SUBMODULE_USAGE:
         PLUGIN_NAME = name
 
     return name
@@ -167,7 +167,7 @@ def slug_name() -> str:
 
     # if qgis plugin tools is run as a dependency, global var cannot be set
     # since it might confuse multiple plugins in the same env using this fn
-    if not _IS_SUBMODULE_USAGE:
+    if _IS_SUBMODULE_USAGE:
         SLUG_NAME = slug
 
     return slug

--- a/tools/ui.py
+++ b/tools/ui.py
@@ -1,0 +1,52 @@
+import importlib.resources
+from typing import Any, Dict, Type
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QWidget
+
+from .resources import package_file
+
+
+class CompiledUI:
+    # provided by pyuic .ui file compilation
+    def setupUi(self, instance: QWidget) -> None:  # noqa: N802
+        ...
+
+
+def load_ui_file(package: importlib.resources.Package, ui_file_name: str) -> Any:
+    """
+    Use like importlib.resources to load a single ui file from a package to a class:
+
+    ```
+    MyUi: Type[QDockWidget] = load_ui_file(my.imported.module, "dock_widget.ui")
+    ```
+
+    Type the return as a type of the ui file subclass, and build the class with
+    type-ignore on the inheritance. Mypy cannot statically determine the dynamic
+    base class without a plugin, but for example Pylance can still provide
+    autocomplete for the implementation methods:
+
+    ```
+    class MyImplementation(MyUi):  # type: ignore
+        def __init__(self):
+            super().__init__()  # Pylance will show QDockWidget init signature
+    ```
+    """
+    # TODO: add mypy plugin to support usage without type-ignores?
+
+    ui_file_path = package_file(package, ui_file_name)
+
+    ui_class: Type[CompiledUI]
+    base_class: Type[QWidget]
+    ui_class, base_class = uic.loadUiType(str(ui_file_path))
+
+    class UiFileWidget(base_class, ui_class):  # type: ignore
+        def __init__(
+            self,
+            *args: Any,
+            **kwargs: Dict[str, Any],
+        ) -> None:
+            super().__init__(*args, **kwargs)
+            self.setupUi(self)
+
+    return UiFileWidget


### PR DESCRIPTION
- Use importlib.resources for file access (i.e. `package_file(__package__, 'file.txt')` and ensure the file exists and is a regular file on disk (no zip extractions) for later access to succeed
- Fix existing bug for caching plugin name requests, option was reversed so development-time dependency usage was broken when multiple plugins were in use

Needs a new release to PyPI.