### PR TITLE
Support subplugins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         qgis-image-tag:
-          - release-3_16
           - release-3_22
           - release-3_28
+          - release-3_34
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Change the implementation of `resources.package_file()` to support Python 3.8
 - Refactor: Changed the plugin identification logic used in `resources.plugin_path()`
 - Maintenance: Updated development dependencies
+- Maintenance: Test on three latest LTR release. That means we drop support for QGIS 3.16.
 
 ## [0.3.2] - 2023-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Feature: New method `resources.load_ui_from_file()` to load a ui file from direct filepath
+- Feature: Support subplugins. In some special cases it is wanted to include a plugin inside another. Now `resources.plugin_path()` supports this.
+- Fix: Change the implementation of `resources.package_file()` to support Python 3.8
+- Refactor: Changed the plugin identification logic used in `resources.plugin_path()`
+- Maintenance: Updated development dependencies
+
 ## [0.3.2] - 2023-11-29
 
 - Fix: Recover from `TypeError` when getting plugin path. Enables pytest-xdist usage.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,117 +6,116 @@
 #
 astor==0.8.1
     # via flake8-qgis
-attrs==22.2.0
+attrs==23.2.0
     # via
     #   flake8-annotations
     #   flake8-bugbear
-    #   pytest
-black==23.1.0
+black==23.12.1
     # via -r requirements-dev.in
-certifi==2022.12.7
+certifi==2023.11.17
     # via requests
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.0.1
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via black
 colorama==0.4.6
     # via
     #   click
     #   pytest
-distlib==0.3.6
+distlib==0.3.8
     # via virtualenv
-exceptiongroup==1.1.0
+exceptiongroup==1.2.0
     # via pytest
-filelock==3.9.0
+filelock==3.13.1
     # via virtualenv
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-dev.in
     #   flake8-annotations
     #   flake8-bugbear
     #   flake8-qgis
     #   pep8-naming
-flake8-annotations==3.0.0
+flake8-annotations==3.0.1
     # via -r requirements-dev.in
-flake8-bugbear==23.1.20
+flake8-bugbear==24.1.16
     # via -r requirements-dev.in
 flake8-qgis==1.0.0
     # via -r requirements-dev.in
-identify==2.5.17
+identify==2.5.33
     # via pre-commit
-idna==3.4
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
 mccabe==0.7.0
     # via flake8
-mypy==1.0.0
+mypy==1.8.0
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nodeenv==1.7.0
+nodeenv==1.8.0
     # via pre-commit
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   pytest
-pathspec==0.11.0
+pathspec==0.12.1
     # via black
 pep8-naming==0.13.3
     # via -r requirements-dev.in
-platformdirs==3.0.0
+platformdirs==4.1.0
     # via
     #   black
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-pre-commit==3.1.1
+pre-commit==3.6.0
     # via -r requirements-dev.in
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
 pyqt5-stubs==5.15.6.0
     # via -r requirements-dev.in
-pytest==7.2.1
+pytest==7.4.4
     # via
     #   -r requirements-dev.in
     #   pytest-mock
     #   pytest-qgis
     #   pytest-qt
     #   pytest-timeout
-pytest-mock==3.10.0
+pytest-mock==3.12.0
     # via -r requirements-dev.in
-pytest-qgis==1.3.2
+pytest-qgis==2.0.0
     # via -r requirements-dev.in
-pytest-qt==4.2.0
+pytest-qt==4.3.1
     # via -r requirements-dev.in
-pytest-timeout==2.1.0
+pytest-timeout==2.2.0
     # via -r requirements-dev.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via pre-commit
-requests==2.28.2
+requests==2.31.0
     # via -r requirements-dev.in
 tomli==2.0.1
     # via
     #   black
     #   mypy
     #   pytest
-types-requests==2.28.11.12
+types-requests==2.31.0.20240106
     # via -r requirements-dev.in
-types-urllib3==1.26.25.5
-    # via types-requests
-typing-extensions==4.4.0
+typing-extensions==4.9.0
     # via
     #   black
     #   mypy
-urllib3==1.26.14
-    # via requests
-virtualenv==20.19.0
+urllib3==2.1.0
+    # via
+    #   requests
+    #   types-requests
+virtualenv==20.25.0
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -297,11 +297,16 @@ def package_file(package: importlib.resources.Package, file_name: str) -> Path:
 
     Use like importlib.resources, provide a package (module or string)
     and file name/path inside the package.
+
+    >>> package_file('myplugin.resources', 'image.svg')
+    C:/Users/me/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins/myplugin/resources/image.svg
+
+    >>> import myplugin.resources
+    >>> package_file(myplugin.resources, 'image.svg')
+    C:/Users/me/AppData/Roaming/QGIS/QGIS3/profiles/default/python/plugins/myplugin/resources/image.svg
     """
 
-    with importlib.resources.as_file(
-        importlib.resources.files(package).joinpath(file_name)
-    ) as requested_path:
+    with importlib.resources.path(package, file_name) as requested_path:
         if not requested_path.is_file():
             raise FileNotFoundError(
                 f"requested file {file_name} not found in {package}"

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -5,10 +5,14 @@ import inspect
 import sys
 from os.path import abspath, dirname, exists, join, pardir
 from pathlib import Path
-from typing import Dict, Iterator, NamedTuple, Optional
+from typing import TYPE_CHECKING, Dict, Iterator, NamedTuple, Optional
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog, QWidget
+
+if TYPE_CHECKING:
+    import os
+    from typing import Union
 
 __copyright__ = (
     "Copyright 2019, 3Liz, 2020-2021 Gispo Ltd, "
@@ -320,7 +324,12 @@ def load_ui(*args: str) -> QWidget:
 
     :return: Compiled UI file.
     """
-    ui_class, _ = uic.loadUiType(resources_path("ui", *args))
+    ui_file_path = resources_path("ui", *args)
+    return load_ui_from_file(ui_file_path)
+
+
+def load_ui_from_file(ui_file_path: "Union[str, os.PathLike]") -> QWidget:
+    ui_class, _ = uic.loadUiType(ui_file_path)
     return ui_class
 
 


### PR DESCRIPTION
In some special cases it is wanted to add an existing plugin inside another plugin. In these cases `plugin_path()` failed to give the subplugin path and gave the main plugin path instead.