### PR TITLE
Custom logger name for log_if_fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Feat: Support custom logger names for `log_if_fails` decorator
+
 ## [0.4.1] - 2024-2-1
 
 - Fix: Fix submodule usage detection when installed as an embedded dependency

--- a/tools/decorations.py
+++ b/tools/decorations.py
@@ -3,35 +3,48 @@ __license__ = "GPL version 2"
 __email__ = "info@gispo.fi"
 __revision__ = "$Format:%H$"
 
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from .exceptions import QgsPluginException
 from .i18n import tr
-from .messages import MsgBar
+from .messages import MessageBarLogger
 from .tasks import FunctionTask
 
 
-def log_if_fails(fn: Callable) -> Callable:
+def log_if_fails(
+    fn: Optional[Callable] = None, /, *, logger_name: str = __name__
+) -> Callable:
     """
     Use this as a decorator with functions and methods that
     might throw uncaught exceptions.
     """
     from functools import wraps
 
-    @wraps(fn)
-    def wrapper(*args: Any, **kwargs: Any) -> None:  # noqa: ANN001
-        try:
-            # Qt injects False into some signals
-            if args[1:] != (False,):
-                fn(*args, **kwargs)
-            else:
-                fn(*args[:-1], **kwargs)
-        except QgsPluginException as e:
-            MsgBar.exception(e, **e.bar_msg, stack_info=True)
-        except Exception as e:
-            MsgBar.exception(tr("Unhandled exception occurred"), e, stack_info=True)
+    # caller is at depth 3 (MessageBarLogger log call, this function, actual call)
+    message_bar = MessageBarLogger(logger_name, stack_level=3)
 
-    return wrapper
+    def decorator(fn: Callable) -> Callable:
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> None:  # noqa: ANN001
+            try:
+                # Qt injects False into some signals
+                if args[1:] != (False,):
+                    fn(*args, **kwargs)
+                else:
+                    fn(*args[:-1], **kwargs)
+            except QgsPluginException as e:
+                message_bar.exception(e, **e.bar_msg, stack_info=True)
+            except Exception as e:
+                message_bar.exception(
+                    tr("Unhandled exception occurred"), e, stack_info=True
+                )
+
+        return wrapper
+
+    if fn is None:
+        return decorator
+
+    return decorator(fn)
 
 
 def taskify(fn: Callable) -> Callable:


### PR DESCRIPTION
Support current api with `@log_if_fails`, or new kw-only `@log_if_fails(logger_name=__name__)` to use a specific logger name for the internal `MessageBarLogger`, and not the `qgis_plugin_tools`-module namespace one.

New minor release this for new feature?