### PR TITLE
Fix log rotation

### DIFF
--- a/tools/custom_logging.py
+++ b/tools/custom_logging.py
@@ -290,7 +290,9 @@ def _create_handlers(
             "".join((c if c.isalnum() else "_") for c in message_log_name) + ".log"
         )
         file_handler = RotatingFileHandler(
-            str(get_log_folder() / log_file_name), maxBytes=1024 * 1024 * 2
+            str(get_log_folder() / log_file_name),
+            maxBytes=1024 * 1024 * 2,
+            backupCount=5,
         )
         file_handler.setLevel(file_level)
         file_formatter = logging.Formatter(


### PR DESCRIPTION
Logs were never rotated because only the maxBytes value was set, not backupCount. Both are necessary!

https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler says `if either of maxBytes or backupCount is zero, rollover never occurs, so you generally want to set backupCount to at least 1`

5 was simply taken from the Python documentation, it seems like a reasonable value to me.
