### PR TITLE
Add qt6 and QGIS 4 support

### DIFF
--- a/test/test_decorations.py
+++ b/test/test_decorations.py
@@ -50,28 +50,28 @@ class MockClass:
 
 def test_logging_if_fails(initialize_logger, qgis_iface):
     function_that_shows_msg()
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
     assert "Error message:Please implement" in messages
 
 
 def test_logging_if_fails_method(initialize_logger, qgis_iface):
     MockClass().method_that_shows_msg()
 
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
     assert "M: Error message:Please implement" in messages
 
 
 def test_logging_if_fails_without_details(initialize_logger, qgis_iface):
     function_that_fails(1, 2, 3, kwarg2=4)
 
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
     assert "Unhandled exception occurred:Error message" in messages
 
 
 def test_logging_if_fails_without_details_method(initialize_logger, qgis_iface):
     MockClass().method_that_fails(1, 2, 3, kwarg2=4)
 
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
     assert "Unhandled exception occurred:M: Error message" in messages
 
 

--- a/test/test_layers.py
+++ b/test/test_layers.py
@@ -9,6 +9,8 @@ from ..tools.layers import LayerType
 
 
 def test_layer_type():
-    assert LayerType.from_wkb_type(QgsWkbTypes.CurvePolygonZM) == LayerType.Polygon
-    assert LayerType.from_wkb_type(QgsWkbTypes.MultiPoint) == LayerType.Point
-    assert LayerType.from_wkb_type(QgsWkbTypes.MultiLineString25D) == LayerType.Line
+    assert LayerType.from_wkb_type(QgsWkbTypes.Type.CurvePolygonZM) == LayerType.Polygon
+    assert LayerType.from_wkb_type(QgsWkbTypes.Type.MultiPoint) == LayerType.Point
+    assert (
+        LayerType.from_wkb_type(QgsWkbTypes.Type.MultiLineString25D) == LayerType.Line
+    )

--- a/test/test_raster_layers.py
+++ b/test/test_raster_layers.py
@@ -7,7 +7,7 @@ import datetime
 
 import pytest
 from qgis.core import QgsDateTimeRange, QgsRasterLayer, QgsSingleBandGrayRenderer
-from qgis.PyQt.QtCore import QDateTime, Qt
+from qgis.PyQt.QtCore import QDate, QDateTime, Qt, QTime
 
 from ..testing.utilities import qgis_supports_temporal
 from ..tools.network import download_to_file
@@ -54,8 +54,8 @@ def test_set_fixed_temporal_range(netcdf_layer, t_range):
     tprops = netcdf_layer.temporalProperties()
     assert tprops.isActive()
     assert tprops.fixedTemporalRange() == QgsDateTimeRange(
-        QDateTime(2020, 11, 2, 15, 0, 0, 0, Qt.TimeSpec(1)),
-        QDateTime(2020, 11, 3, 11, 0, 0, 0, Qt.TimeSpec(1)),
+        QDateTime(QDate(2020, 11, 2), QTime(15, 0, 0, 0), Qt.TimeSpec(1)),
+        QDateTime(QDate(2020, 11, 3), QTime(11, 0, 0, 0), Qt.TimeSpec(1)),
     )
 
 
@@ -97,8 +97,8 @@ def test_set_band_based_on_range3(configured_layer):
 )
 def test_set_band_based_on_range4(configured_layer):
     t_range2 = QgsDateTimeRange(
-        QDateTime(2020, 11, 3, 10, 0, 0, 0, Qt.TimeSpec(1)),
-        QDateTime(2020, 11, 3, 11, 0, 0, 0, Qt.TimeSpec(1)),
+        QDateTime(QDate(2020, 11, 3), QTime(10, 0, 0, 0), Qt.TimeSpec(1)),
+        QDateTime(QDate(2020, 11, 3), QTime(11, 0, 0, 0), Qt.TimeSpec(1)),
     )
     band_number = set_band_based_on_range(configured_layer, t_range2)
     assert band_number == 20

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -31,9 +31,11 @@ def test_run_simple_task_canceled(task_runner: TestTaskRunner, qgis_iface):
     success = task_runner.run_task(task, cancel=True)
 
     # for some reason this randomly fails if the signal is not waited for
-    QCoreApplication.processEvents(QEventLoop.AllEvents, 100)  # 100 ms wait
+    QCoreApplication.processEvents(
+        QEventLoop.ProcessEventsFlag.AllEvents, 100
+    )  # 100 ms wait
 
-    messages = qgis_iface.messageBar().get_messages(Qgis.Warning)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Warning)
 
     assert not success
     assert task_runner.fail
@@ -48,7 +50,7 @@ def test_run_simple_task_canceled_after_a_while(
 ):
     task = SimpleTask()
     success = task_runner.run_task(task, cancel=True, sleep_before_cancel=0.01)
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
 
     assert not success
     assert task_runner.fail
@@ -59,7 +61,7 @@ def test_run_simple_task_canceled_after_a_while(
 def test_run_simple_task_failed(task_runner: TestTaskRunner, qgis_iface):
     task = SimpleTask(True)
     success = task_runner.run_task(task)
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
 
     assert not success
     assert task_runner.fail
@@ -71,7 +73,7 @@ def test_run_simple_task_failed_with_qgs_plugin_exception(
 ):
     task = SimpleTask(True, QgsPluginException)
     success = task_runner.run_task(task)
-    messages = qgis_iface.messageBar().get_messages(Qgis.Critical)
+    messages = qgis_iface.messageBar().get_messages(Qgis.MessageLevel.Critical)
 
     assert not success
     assert task_runner.fail

--- a/tools/algorithm_processing.py
+++ b/tools/algorithm_processing.py
@@ -21,7 +21,7 @@ class BaseProcessingAlgorithm(QgsProcessingAlgorithm):
         return type(self)()
 
     def flags(self):
-        return super().flags() | QgsProcessingAlgorithm.FlagHideFromModeler
+        return super().flags() | QgsProcessingAlgorithm.Flag.FlagHideFromModeler
 
     def icon(self):
         icon = resources_path("icons", "icon.png")

--- a/tools/custom_logging.py
+++ b/tools/custom_logging.py
@@ -55,17 +55,17 @@ def qgis_level(logging_level: str) -> int:
     :rtype: Qgis.MessageLevel
     """
     if logging_level == "CRITICAL":
-        return Qgis.Critical
+        return Qgis.MessageLevel.Critical
     elif logging_level == "ERROR":
-        return Qgis.Critical
+        return Qgis.MessageLevel.Critical
     elif logging_level == "WARNING":
-        return Qgis.Warning
+        return Qgis.MessageLevel.Warning
     elif logging_level == "INFO":
-        return Qgis.Info
+        return Qgis.MessageLevel.Info
     elif logging_level == "DEBUG":
-        return Qgis.Info
+        return Qgis.MessageLevel.Info
 
-    return Qgis.Info
+    return Qgis.MessageLevel.Info
 
 
 def bar_msg(
@@ -116,7 +116,9 @@ class QgsLogHandler(logging.Handler):
             ).format(self._message_log_name)
             # print(message)
             # noinspection PyCallByClass,PyTypeChecker
-            QgsMessageLog.logMessage(message, level=Qgis.Critical, **tag_kwargs)
+            QgsMessageLog.logMessage(
+                message, level=Qgis.MessageLevel.Critical, **tag_kwargs
+            )
 
 
 class QgsMessageBarFilter(logging.Filter):
@@ -140,7 +142,7 @@ class QgsMessageBarFilter(logging.Filter):
         record.qgis_level = (  # type: ignore
             qgis_level(record.levelname)
             if not args.get("success", False)
-            else Qgis.Success
+            else Qgis.MessageLevel.Success
         )
         record.duration = args.get("duration", self.bar_msg_duration(record.levelname))  # type: ignore # noqa E501
         return True

--- a/tools/fields.py
+++ b/tools/fields.py
@@ -88,6 +88,6 @@ def value_for_widget(widget: Type[QWidget]) -> Union[str, bool, float, int]:
 def provider_fields(fields: QgsFields) -> QgsFields:
     flds = QgsFields()
     for i in range(fields.count()):
-        if fields.fieldOrigin(i) == QgsFields.OriginProvider:
+        if fields.fieldOrigin(i) == QgsFields.FieldOrigin.OriginProvider:
             flds.append(fields.at(i))
     return flds

--- a/tools/layers.py
+++ b/tools/layers.py
@@ -32,18 +32,18 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 
 POINT_TYPES = {
-    QgsWkbTypes.Point,
-    QgsWkbTypes.MultiPoint,
+    QgsWkbTypes.Type.Point,
+    QgsWkbTypes.Type.MultiPoint,
 }
 
 LINE_TYPES = {
-    QgsWkbTypes.LineString,
-    QgsWkbTypes.MultiLineString,
+    QgsWkbTypes.Type.LineString,
+    QgsWkbTypes.Type.MultiLineString,
 }
 POLYGON_TYPES = {
-    QgsWkbTypes.Polygon,
-    QgsWkbTypes.MultiPolygon,
-    QgsWkbTypes.CurvePolygon,
+    QgsWkbTypes.Type.Polygon,
+    QgsWkbTypes.Type.MultiPolygon,
+    QgsWkbTypes.Type.CurvePolygon,
 }
 
 
@@ -88,8 +88,10 @@ def set_temporal_settings(
     :param unit: QgsUnitTypes.TemporalUnit
     """
     if unit is None:
-        unit = QgsUnitTypes.TemporalMinutes
-    mode = QgsVectorLayerTemporalProperties.ModeFeatureDateTimeInstantFromField
+        unit = QgsUnitTypes.TemporalUnit.TemporalMinutes
+    mode = (
+        QgsVectorLayerTemporalProperties.TemporalMode.ModeFeatureDateTimeInstantFromField  # noqa: E501
+    )
     tprops: QgsVectorLayerTemporalProperties = layer.temporalProperties()
     tprops.setMode(mode)
     tprops.setStartField(dt_field)

--- a/tools/network.py
+++ b/tools/network.py
@@ -170,7 +170,7 @@ def request_raw(
             byte_data = bytes(json.dumps(data), encoding)
             req.setRawHeader(
                 b"Content-Type",
-                bytes(f"application/json; charset={encoding}", encoding),
+                bytes(f"application/json; charset={encoding}", encoding),  # noqa: E702
             )
         elif files:
             # Support multipart binary. Generate boundary like
@@ -188,8 +188,8 @@ def request_raw(
                 content = file_info[1]
                 content_type = file_info[2]
                 content_disposition_form_data = (
-                    f"Content-Disposition: form-data;"
-                    f' name="{name}";'
+                    f"Content-Disposition: form-data;"  # noqa: E702, E231
+                    f' name="{name}";'  # noqa: E702, E231
                     f' filename="{file_name}"\r\n'
                 )
                 content_type_form_data = f"Content-Type: {content_type}\r\n\r\n"
@@ -202,7 +202,9 @@ def request_raw(
             byte_data += last_byte_boundary
             req.setRawHeader(
                 b"Content-Type",
-                bytes(f"multipart/form-data; boundary={boundary}", encoding),
+                bytes(
+                    f"multipart/form-data; boundary={boundary}", encoding  # noqa: E702
+                ),
             )
         else:
             byte_data = b""
@@ -211,7 +213,7 @@ def request_raw(
         raise Exception(f"Request method {method} not supported.")
     reply: QgsNetworkReplyContent = request_blocking.reply()
     reply_error = reply.error()
-    if reply_error != QNetworkReply.NoError:
+    if reply_error != QNetworkReply.NetworkError.NoError:
         # Error content will be empty in older QGIS versions:
         # https://github.com/qgis/QGIS/issues/42442
         message = (

--- a/tools/raster_layers.py
+++ b/tools/raster_layers.py
@@ -35,13 +35,15 @@ def set_raster_renderer_to_singleband(layer: QgsRasterLayer, band: int = 1) -> N
     )
 
     stats: QgsRasterBandStats = provider.bandStatistics(
-        band, QgsRasterBandStats.All, layer.extent(), 0
+        band, QgsRasterBandStats.Stats.All, layer.extent(), 0
     )
     min_val = max(stats.minimumValue, 0)
     max_val = max(stats.maximumValue, 0)
 
     enhancement = QgsContrastEnhancement(renderer.dataType(band))
-    contrast_enhancement = QgsContrastEnhancement.StretchToMinimumMaximum
+    contrast_enhancement = (
+        QgsContrastEnhancement.ContrastEnhancementAlgorithm.StretchToMinimumMaximum
+    )
     enhancement.setContrastEnhancementAlgorithm(contrast_enhancement, True)
     enhancement.setMinimumValue(min_val)
     enhancement.setMaximumValue(max_val)
@@ -56,7 +58,7 @@ def set_fixed_temporal_range(layer: QgsRasterLayer, t_range: QgsDateTimeRange) -
     :param layer: raster layer
     :param t_range: fixed temporal range
     """
-    mode = QgsRasterLayerTemporalProperties.ModeFixedTemporalRange
+    mode = QgsRasterLayerTemporalProperties.TemporalMode.ModeFixedTemporalRange
     tprops: QgsRasterLayerTemporalProperties = layer.temporalProperties()
     tprops.setMode(mode)
     if t_range.begin().timeSpec() == 0 or t_range.end().timeSpec() == 0:
@@ -83,7 +85,10 @@ def set_band_based_on_range(layer: QgsRasterLayer, t_range: QgsDateTimeRange) ->
         and t_range.begin().isValid()
         and t_range.end().isValid()
     ):
-        if tprops.mode() == QgsRasterLayerTemporalProperties.ModeFixedTemporalRange:
+        if (
+            tprops.mode()
+            == QgsRasterLayerTemporalProperties.TemporalMode.ModeFixedTemporalRange
+        ):
             layer_t_range: QgsDateTimeRange = tprops.fixedTemporalRange()
             start: datetime.datetime = layer_t_range.begin().toPyDateTime()
             end: datetime.datetime = layer_t_range.end().toPyDateTime()

--- a/tools/resources.py
+++ b/tools/resources.py
@@ -386,7 +386,7 @@ def package_file(package: importlib.resources.Package, file_name: str) -> Path:
     with importlib.resources.path(package, file_name) as requested_path:
         if not requested_path.is_file():
             raise FileNotFoundError(
-                f"requested file {file_name} not found in {package}"
+                f"requested file {file_name} not found in {package}"  # noqa: E713
             )
 
     if not requested_path.is_file():

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -21,7 +21,7 @@ def get_setting(
     default: Optional[Any] = None,
     typehint: Optional[type] = None,
     internal: bool = True,
-    section: int = QgsSettings.NoSection,
+    section: int = QgsSettings.Section.NoSection,
 ) -> Union[QVariant, str]:
     """
     Get QGIS setting value plugin
@@ -45,7 +45,7 @@ def set_setting(
     key: str,
     value: Union[str, int, float, bool],
     internal: bool = True,
-    section: int = QgsSettings.NoSection,
+    section: int = QgsSettings.Section.NoSection,
 ) -> bool:
     """
     Set a value in the QgsSetting

--- a/tools/tasks.py
+++ b/tools/tasks.py
@@ -22,7 +22,7 @@ class BaseTask(QgsTask):
     """
 
     def __init__(self) -> None:
-        super().__init__(self.name, QgsTask.CanCancel)
+        super().__init__(self.name, QgsTask.Flag.CanCancel)
         self.exception: Optional[Exception] = None
 
     @property
@@ -56,7 +56,7 @@ class BaseTask(QgsTask):
         if result:
             LOGGER.debug(
                 f"Task {self.name} ended successfully in "
-                f"{self.elapsedTime() / 1000:.2f}!"
+                f"{self.elapsedTime() / 1000:.2f}!"  # noqa: E231
             )
             pass
         else:

--- a/widgets/list_fields_selection.py
+++ b/widgets/list_fields_selection.py
@@ -13,8 +13,8 @@ __revision__ = "$Format:%H$"
 class ListFieldsSelection(QListWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setSelectionMode(QAbstractItemView.MultiSelection)
-        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
+        self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.layer = None
 
     def set_layer(self, layer: QgsVectorLayer):
@@ -29,7 +29,7 @@ class ListFieldsSelection(QListWidget):
                 cell.setText(field.name())
             else:
                 cell.setText("{} ({})".format(field.name(), alias))
-            cell.setData(Qt.UserRole, field.name())
+            cell.setData(Qt.ItemDataRole.UserRole, field.name())
             index = layer.fields().indexFromName(field.name())
             if index >= 0:
                 cell.setIcon(self.layer.fields().iconForField(index))
@@ -38,12 +38,12 @@ class ListFieldsSelection(QListWidget):
     def set_selection(self, fields: tuple):
         for i in range(self.count()):
             item = self.item(i)
-            item.setSelected(item.data(Qt.UserRole) in fields)
+            item.setSelected(item.data(Qt.ItemDataRole.UserRole) in fields)
 
     def selection(self) -> list:
         selection = []
         for i in range(self.count()):
             item = self.item(i)
             if item.isSelected():
-                selection.append(item.data(Qt.UserRole))
+                selection.append(item.data(Qt.ItemDataRole.UserRole))
         return selection

--- a/widgets/list_layers_selection.py
+++ b/widgets/list_layers_selection.py
@@ -14,8 +14,8 @@ __revision__ = "$Format:%H$"
 class ListLayersSelection(QListWidget):
     def __init__(self, parent: QWidget = None) -> None:
         super().__init__(parent)
-        self.setSelectionMode(QAbstractItemView.MultiSelection)
-        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
+        self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.project: Optional[QgsProject] = None
 
     def set_project(self, project: QgsProject) -> None:
@@ -24,7 +24,7 @@ class ListLayersSelection(QListWidget):
         self.clear()
 
         for layer in self.project.mapLayers().values():
-            if layer.type() != QgsMapLayer.VectorLayer:
+            if layer.type() != QgsMapLayer.LayerType.VectorLayer:
                 continue
 
             if not layer.isSpatial():
@@ -32,19 +32,19 @@ class ListLayersSelection(QListWidget):
 
             cell = QListWidgetItem()
             cell.setText(layer.name())
-            cell.setData(Qt.UserRole, layer.id())
+            cell.setData(Qt.ItemDataRole.UserRole, layer.id())
             cell.setIcon(QgsMapLayerModel.iconForLayer(layer))
             self.addItem(cell)
 
     def set_selection(self, layers: tuple) -> None:
         for i in range(self.count()):
             item = self.item(i)
-            item.setSelected(item.data(Qt.UserRole) in layers)
+            item.setSelected(item.data(Qt.ItemDataRole.UserRole) in layers)
 
     def selection(self) -> list:
         selection = []
         for i in range(self.count()):
             item = self.item(i)
             if item.isSelected():
-                selection.append(item.data(Qt.UserRole))
+                selection.append(item.data(Qt.ItemDataRole.UserRole))
         return selection

--- a/widgets/progress_dialog.py
+++ b/widgets/progress_dialog.py
@@ -55,7 +55,10 @@ class ProgressDialog(QDialog, FORM_CLASS):
             self.push_btn.setText(abort_btn_text)
             layout = QHBoxLayout()
             spacer = QSpacerItem(
-                100, 20, QSizePolicy.MinimumExpanding, QSizePolicy.Expanding
+                100,
+                20,
+                QSizePolicy.Policy.MinimumExpanding,
+                QSizePolicy.Policy.Expanding,
             )
             layout.addSpacerItem(spacer)
             layout.addWidget(self.push_btn)

--- a/widgets/selectable_combobox.py
+++ b/widgets/selectable_combobox.py
@@ -30,8 +30,8 @@ class CheckableComboBox:
             self.select_all.clicked.connect(self.select_all_clicked)
 
     def select_all_clicked(self):
-        for item in self.model.findItems("*", Qt.MatchWildcard):
-            item.setCheckState(Qt.Checked)
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
+            item.setCheckState(Qt.CheckState.Checked)
 
     def append_row(self, item: QStandardItem):
         """Add an item to the combobox."""
@@ -46,15 +46,17 @@ class CheckableComboBox:
 
     def selected_items(self) -> list:
         checked_items = []
-        for item in self.model.findItems("*", Qt.MatchWildcard):
-            if item.checkState() == Qt.Checked:
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
+            if item.checkState() == Qt.CheckState.Checked:
                 checked_items.append(item.data())
         return checked_items
 
     def set_selected_items(self, items):
-        for item in self.model.findItems("*", Qt.MatchWildcard):
+        for item in self.model.findItems("*", Qt.MatchFlag.MatchWildcard):
             checked = item.data() in items
-            item.setCheckState(Qt.Checked if checked else Qt.Unchecked)
+            item.setCheckState(
+                Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked
+            )
 
     def text_changed(self, text):
         """Update the preview with all selected items, separated by a comma."""
@@ -73,7 +75,7 @@ class CheckableFieldComboBox(CheckableComboBox):
 
         if not layer:
             return
-        if layer.type() != QgsMapLayer.VectorLayer:
+        if layer.type() != QgsMapLayer.LayerType.VectorLayer:
             return
 
         self.layer = layer


### PR DESCRIPTION
This PR uses official [QGIS migration instructions ](https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6) to add QT6 and QGIS>=4.0 support while being still backwards compatible with QT5 and QGIS 3.x versions. 